### PR TITLE
chore: update benchmark tool

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -9,7 +9,9 @@
       "Bash(go run:*)",
       "Bash(mkdir:*)",
       "Bash(mv:*)",
-      "mcp__ide__getDiagnostics"
+      "mcp__ide__getDiagnostics",
+      "Bash(find:*)",
+      "Bash(ls:*)"
     ],
     "deny": [
       "Bash(rm:*)"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ The codebase is organized as follows:
 - **Root package (`tokenbucket`)**: Main interface and implementation
   - `tokenbucket.go`: `TokenBucket` interface with `Take()` and `Get()` methods and `Bucket` struct implementation
   - `tokenbucket_test.go`: Unit tests for the main tokenbucket functionality
-  - `main_test.go`: Test utilities for the root package
+  - `main_test.go`: Test utilities and setup for the root package
   - Uses the `github.com/mennanov/limiters` library as the underlying implementation
   - `errors.go`: Custom error definitions for the library
 
@@ -72,6 +72,10 @@ make benchmark
 # or
 go test -bench=. -benchmem ./benchmark
 
+# Run CLI benchmark tool
+cd benchmark/cmd/benchmark
+go run main.go -scenario=single -concurrency=10 -duration=60s
+
 # Get dependencies
 go mod tidy
 
@@ -102,9 +106,16 @@ The project includes comprehensive test coverage:
 - **Single Dimension Tests** (`tokenbucket_single_dimension_test.go`): Performance testing with high load on a single dimension
   - Memory backend benchmark
   - Tests with and without distributed locking
+  - Configuration: Capacity=1000, FillRate=100 tokens/second, 10 goroutines
 - **Multiple Dimension Tests** (`tokenbucket_multiple_dimension_test.go`): Performance testing across multiple dimensions (10 dimensions)
   - Round-robin token acquisition across dimensions
   - Memory backend and distributed scenarios
+  - Configuration per dimension: Capacity=1000, FillRate=100 tokens/second, 10 goroutines
+- **CLI Benchmark Tool** (`cmd/benchmark/main.go`): Command-line tool for sustained load testing
+  - Real-time metrics with 1-second snapshots
+  - Multiple scenarios (single, multi) and backend types (custom, memory, limiters)
+  - Provider support for local DynamoDB and AWS DynamoDB
+  - Report generation and optional file output
 - Metrics collection for throughput and latency analysis
 - Comparative testing between local and DynamoDB implementations
 

--- a/benchmark/cmd/benchmark/main.go
+++ b/benchmark/cmd/benchmark/main.go
@@ -160,9 +160,10 @@ func runLoadTest(bucket *tokenbucket.Bucket, metrics *benchmark.Metrics, cfg Con
 			select {
 			case <-ticker.C:
 				snapshot := metrics.TakeSnapshot()
-				log.Printf("Snapshot: %d ops, %.2f ops/sec, Success: %d, Failed: %d",
-					snapshot.TotalOperations, snapshot.OpsPerSecond,
-					snapshot.SuccessfulTakes, snapshot.FailedTakes)
+				log.Printf(
+					"Snapshot: %d ops, %.2f ops/sec, Avg Latency: %.2fms, Success: %d, Failed: %d",
+					snapshot.TotalOperations, snapshot.OpsPerSecond, snapshot.AvgLatencyMs, snapshot.SuccessfulTakes, snapshot.FailedTakes,
+				)
 			case <-ctx.Done():
 				return
 			}
@@ -217,9 +218,10 @@ func runMultiDimensionalLoadTest(buckets []*tokenbucket.Bucket, metrics *benchma
 			select {
 			case <-ticker.C:
 				snapshot := metrics.TakeSnapshot()
-				log.Printf("Multi-dimension Snapshot: %d ops, %.2f ops/sec, Success: %d, Failed: %d",
-					snapshot.TotalOperations, snapshot.OpsPerSecond,
-					snapshot.SuccessfulTakes, snapshot.FailedTakes)
+				log.Printf(
+					"Snapshot: %d ops, %.2f ops/sec, Avg Latency: %.2fms, Success: %d, Failed: %d",
+					snapshot.TotalOperations, snapshot.OpsPerSecond, snapshot.AvgLatencyMs, snapshot.SuccessfulTakes, snapshot.FailedTakes,
+				)
 			case <-ctx.Done():
 				return
 			}

--- a/benchmark/cmd/benchmark/main.go
+++ b/benchmark/cmd/benchmark/main.go
@@ -16,15 +16,15 @@ import (
 )
 
 type Config struct {
-	Scenario    string
-	Concurrency int
-	Duration    time.Duration
-	Capacity    int64
-	FillRate    int64
-	Dimensions  int
-	WithLock    bool
-	OutputFile  string
-	Backend     string
+	Scenario     string
+	Concurrency  int
+	Duration     time.Duration
+	Capacity     int64
+	FillRate     int64
+	Dimensions   int
+	WithLock     bool
+	OutputFile   string
+	ProviderType string
 }
 
 func main() {
@@ -85,9 +85,9 @@ func parseFlags() Config {
 	flag.Int64Var(&cfg.Capacity, "capacity", 1000, "Token bucket capacity")
 	flag.Int64Var(&cfg.FillRate, "fill-rate", 100, "Token fill rate per second")
 	flag.IntVar(&cfg.Dimensions, "dimensions", 10, "Number of dimensions for multi-dimension test")
-	flag.BoolVar(&cfg.WithLock, "with-lock", true, "Use distributed locking")
+	flag.BoolVar(&cfg.WithLock, "with-lock", false, "Use distributed locking")
 	flag.StringVar(&cfg.OutputFile, "output", "", "Output file for results (optional)")
-	flag.StringVar(&cfg.Backend, "backend", "local", "Backend type (local, aws)")
+	flag.StringVar(&cfg.ProviderType, "provider-type", "local", "Provider type (local, aws)")
 
 	flag.Parse()
 
@@ -284,12 +284,12 @@ func saveReport(_ benchmark.Report, cfg Config) error {
 
 // getProvider returns the appropriate storage provider based on configuration
 func getProvider(cfg Config) (storage.Provider, error) {
-	switch cfg.Backend {
+	switch cfg.ProviderType {
 	case "local":
 		return storage.GetLocalProvider(), nil
 	case "aws":
 		return storage.GetAWSProvider(), nil
 	default:
-		return nil, fmt.Errorf("unknown backend: %s", cfg.Backend)
+		return nil, fmt.Errorf("unknown provider: %s", cfg.ProviderType)
 	}
 }

--- a/benchmark/cmd/benchmark/main.go
+++ b/benchmark/cmd/benchmark/main.go
@@ -130,7 +130,7 @@ func runMultiDimensionTest(provider storage.Provider, cfg Config) (benchmark.Rep
 		if err != nil {
 			return benchmark.Report{}, err
 		}
-		bucket, err := provider.CreateBucket(cfg.Capacity/5, cfg.FillRate/5, fmt.Sprintf("load-test-multi-%d", i), opts...)
+		bucket, err := provider.CreateBucket(cfg.Capacity, cfg.FillRate, fmt.Sprintf("load-test-multi-%d", i), opts...)
 		if err != nil {
 			return benchmark.Report{}, fmt.Errorf("failed to create bucket %d: %w", i, err)
 		}
@@ -161,7 +161,7 @@ func runLoadTest(bucket *tokenbucket.Bucket, metrics *benchmark.Metrics, cfg Con
 			case <-ticker.C:
 				snapshot := metrics.TakeSnapshot()
 				log.Printf(
-					"Snapshot: %d ops, %.2f ops/sec, Avg Latency: %.2fms, Success: %d, Failed: %d",
+					"Snapshot: %7d ops, %8.2f ops/sec, Avg Latency: %7.2fms, Success: %7d, Failed: %7d",
 					snapshot.TotalOperations, snapshot.OpsPerSecond, snapshot.AvgLatencyMs, snapshot.SuccessfulTakes, snapshot.FailedTakes,
 				)
 			case <-ctx.Done():
@@ -219,7 +219,7 @@ func runMultiDimensionalLoadTest(buckets []*tokenbucket.Bucket, metrics *benchma
 			case <-ticker.C:
 				snapshot := metrics.TakeSnapshot()
 				log.Printf(
-					"Snapshot: %d ops, %.2f ops/sec, Avg Latency: %.2fms, Success: %d, Failed: %d",
+					"Snapshot: %7d ops, %8.2f ops/sec, Avg Latency: %7.2fms, Success: %7d, Failed: %7d",
 					snapshot.TotalOperations, snapshot.OpsPerSecond, snapshot.AvgLatencyMs, snapshot.SuccessfulTakes, snapshot.FailedTakes,
 				)
 			case <-ctx.Done():

--- a/benchmark/storage/storage.go
+++ b/benchmark/storage/storage.go
@@ -14,6 +14,7 @@ type Provider interface {
 	Setup(ctx context.Context) error
 	Cleanup(ctx context.Context) error
 	CreateBucket(capacity, fillRate int64, dimension string, opts ...tokenbucket.Option) (*tokenbucket.Bucket, error)
+	CreateBucketConfig(dimension string) *dynamodbstorage.BucketBackendConfig
 	CreateLockBackendConfig() *dynamodbstorage.LockBackendConfig
 }
 


### PR DESCRIPTION
This pull request introduces significant updates to the benchmarking tool, including enhancements to configuration flexibility, metrics reporting, and backend support. The most notable changes involve the removal of the lock-comparison scenario, the addition of new configuration options for backend and provider types, and improved latency tracking in metrics. Below is a summary of the most important changes grouped by theme:

### Configuration Enhancements:
* Added new fields `BackendType` and `RaceCheck` to the `Config` struct to support different backend types and enable race condition checking. Renamed `Backend` to `ProviderType` for clarity. (`benchmark/cmd/benchmark/main.go`, [benchmark/cmd/benchmark/main.goR26-R31](diffhunk://#diff-ca0cac09d9bb808ecc10f54baec24c257d4628257093d249f970a0f5a98cac18R26-R31))
* Updated `parseFlags()` to include flags for `backend-type` and `race-check` while removing the `lock-comparison` scenario and its associated flag. (`benchmark/cmd/benchmark/main.go`, [benchmark/cmd/benchmark/main.goL84-R112](diffhunk://#diff-ca0cac09d9bb808ecc10f54baec24c257d4628257093d249f970a0f5a98cac18L84-R112))

### Backend Support:
* Introduced `getBackendOptions()` function to dynamically configure backend options based on `BackendType` and `WithLock` settings. (`benchmark/cmd/benchmark/main.go`, [benchmark/cmd/benchmark/main.goL348-R330](diffhunk://#diff-ca0cac09d9bb808ecc10f54baec24c257d4628257093d249f970a0f5a98cac18L348-R330))
* Added a new method `CreateBucketConfig()` to the `Provider` interface for backend configurations specific to the `limiters` backend. (`benchmark/storage/storage.go`, [benchmark/storage/storage.goR17](diffhunk://#diff-90db1e678f093049888fd2fbfbe81d596861dc91d209b1ab52b2701902048fd4R17))

### Metrics Improvements:
* Added `AvgLatencyMs` to `MetricSnapshot` and `Report` to track and report average latency per operation in milliseconds. (`benchmark/metrics.go`, [[1]](diffhunk://#diff-45baf1be2549aaa3116c24c2e301ef6f892d43ed4012c11e2a558fc42319b95cR16) [[2]](diffhunk://#diff-45baf1be2549aaa3116c24c2e301ef6f892d43ed4012c11e2a558fc42319b95cR100)
* Updated `TakeSnapshot()` and `GenerateReport()` methods to calculate and include average latency in metrics. (`benchmark/metrics.go`, [[1]](diffhunk://#diff-45baf1be2549aaa3116c24c2e301ef6f892d43ed4012c11e2a558fc42319b95cR68-R85) [[2]](diffhunk://#diff-45baf1be2549aaa3116c24c2e301ef6f892d43ed4012c11e2a558fc42319b95cR129-R139)

### Code Simplification:
* Removed the `runLockComparisonTest()` function and its associated logic, simplifying the codebase and focusing on single and multi-dimension tests. (`benchmark/cmd/benchmark/main.go`, [benchmark/cmd/benchmark/main.goL140-R147](diffhunk://#diff-ca0cac09d9bb808ecc10f54baec24c257d4628257093d249f970a0f5a98cac18L140-R147))

### Logging and Reporting:
* Enhanced log outputs to include average latency in both single and multi-dimension snapshots, improving visibility into performance metrics. (`benchmark/cmd/benchmark/main.go`, [[1]](diffhunk://#diff-ca0cac09d9bb808ecc10f54baec24c257d4628257093d249f970a0f5a98cac18L198-R166) [[2]](diffhunk://#diff-ca0cac09d9bb808ecc10f54baec24c257d4628257093d249f970a0f5a98cac18L255-R224)
* Updated `printReport()` to display new configuration fields `BackendType` and `RaceCheck`. (`benchmark/cmd/benchmark/main.go`, [benchmark/cmd/benchmark/main.goR271-R273](diffhunk://#diff-ca0cac09d9bb808ecc10f54baec24c257d4628257093d249f970a0f5a98cac18R271-R273))


---

## Benchmark example output

```
% go run ./benchmark/cmd/benchmark/main.go -scenario=single -backend-type custom -capacity 100000 -fill-rate 10000
2025/07/28 22:35:48 Starting 60-second benchmark with config: {Scenario:single Concurrency:10 Duration:1m0s Capacity:100000 FillRate:10000 Dimensions:10 WithLock:false BackendType:custom RaceCheck:false OutputFile: ProviderType:local dimension:}
2025/07/28 22:35:52 Snapshot:     372 ops,   371.84 ops/sec, Avg Latency:   25.59ms, Success:     372, Failed:       0
2025/07/28 22:35:53 Snapshot:     914 ops,   456.90 ops/sec, Avg Latency:   20.71ms, Success:     914, Failed:       0
2025/07/28 22:35:54 Snapshot:    1494 ops,   497.93 ops/sec, Avg Latency:   18.95ms, Success:    1494, Failed:       0
2025/07/28 22:35:55 Snapshot:    2119 ops,   529.70 ops/sec, Avg Latency:   17.76ms, Success:    2119, Failed:       0
2025/07/28 22:35:56 Snapshot:    2730 ops,   545.96 ops/sec, Avg Latency:   17.20ms, Success:    2730, Failed:       0
2025/07/28 22:35:57 Snapshot:    3348 ops,   557.97 ops/sec, Avg Latency:   16.82ms, Success:    3348, Failed:       0
2025/07/28 22:35:58 Snapshot:    3955 ops,   564.97 ops/sec, Avg Latency:   16.59ms, Success:    3955, Failed:       0
2025/07/28 22:35:59 Snapshot:    4551 ops,   568.84 ops/sec, Avg Latency:   16.48ms, Success:    4551, Failed:       0
2025/07/28 22:36:00 Snapshot:    5112 ops,   567.97 ops/sec, Avg Latency:   16.51ms, Success:    5112, Failed:       0
2025/07/28 22:36:01 Snapshot:    5696 ops,   569.58 ops/sec, Avg Latency:   16.46ms, Success:    5696, Failed:       0
2025/07/28 22:36:02 Snapshot:    6329 ops,   575.35 ops/sec, Avg Latency:   16.28ms, Success:    6329, Failed:       0
2025/07/28 22:36:03 Snapshot:    7011 ops,   584.23 ops/sec, Avg Latency:   16.02ms, Success:    7011, Failed:       0
2025/07/28 22:36:04 Snapshot:    7689 ops,   591.44 ops/sec, Avg Latency:   15.81ms, Success:    7689, Failed:       0
2025/07/28 22:36:05 Snapshot:    8318 ops,   594.13 ops/sec, Avg Latency:   15.74ms, Success:    8318, Failed:       0
2025/07/28 22:36:06 Snapshot:    8951 ops,   596.72 ops/sec, Avg Latency:   15.66ms, Success:    8951, Failed:       0
2025/07/28 22:36:07 Snapshot:    9540 ops,   596.23 ops/sec, Avg Latency:   15.67ms, Success:    9540, Failed:       0
2025/07/28 22:36:08 Snapshot:   10245 ops,   602.63 ops/sec, Avg Latency:   15.50ms, Success:   10245, Failed:       0
2025/07/28 22:36:09 Snapshot:   10971 ops,   609.49 ops/sec, Avg Latency:   15.31ms, Success:   10971, Failed:       0
2025/07/28 22:36:10 Snapshot:   11729 ops,   617.30 ops/sec, Avg Latency:   15.11ms, Success:   11729, Failed:       0
2025/07/28 22:36:11 Snapshot:   12472 ops,   623.59 ops/sec, Avg Latency:   14.94ms, Success:   12472, Failed:       0
2025/07/28 22:36:12 Snapshot:   13195 ops,   628.32 ops/sec, Avg Latency:   14.82ms, Success:   13195, Failed:       0
2025/07/28 22:36:13 Snapshot:   13917 ops,   632.58 ops/sec, Avg Latency:   14.71ms, Success:   13917, Failed:       0
2025/07/28 22:36:14 Snapshot:   14572 ops,   633.56 ops/sec, Avg Latency:   14.69ms, Success:   14572, Failed:       0
2025/07/28 22:36:15 Snapshot:   15268 ops,   636.16 ops/sec, Avg Latency:   14.62ms, Success:   15268, Failed:       0
2025/07/28 22:36:16 Snapshot:   15926 ops,   637.03 ops/sec, Avg Latency:   14.60ms, Success:   15926, Failed:       0
2025/07/28 22:36:17 Snapshot:   16629 ops,   639.57 ops/sec, Avg Latency:   14.54ms, Success:   16629, Failed:       0
2025/07/28 22:36:18 Snapshot:   17329 ops,   641.80 ops/sec, Avg Latency:   14.49ms, Success:   17329, Failed:       0
2025/07/28 22:36:19 Snapshot:   18059 ops,   644.96 ops/sec, Avg Latency:   14.41ms, Success:   18059, Failed:       0
2025/07/28 22:36:20 Snapshot:   18780 ops,   647.58 ops/sec, Avg Latency:   14.35ms, Success:   18780, Failed:       0
2025/07/28 22:36:21 Snapshot:   19508 ops,   650.26 ops/sec, Avg Latency:   14.28ms, Success:   19508, Failed:       0
2025/07/28 22:36:22 Snapshot:   20230 ops,   652.57 ops/sec, Avg Latency:   14.23ms, Success:   20230, Failed:       0
2025/07/28 22:36:23 Snapshot:   20920 ops,   653.74 ops/sec, Avg Latency:   14.20ms, Success:   20920, Failed:       0
2025/07/28 22:36:24 Snapshot:   21606 ops,   654.72 ops/sec, Avg Latency:   14.18ms, Success:   21606, Failed:       0
2025/07/28 22:36:25 Snapshot:   22242 ops,   654.17 ops/sec, Avg Latency:   14.19ms, Success:   22242, Failed:       0
2025/07/28 22:36:26 Snapshot:   22842 ops,   652.62 ops/sec, Avg Latency:   14.23ms, Success:   22842, Failed:       0
2025/07/28 22:36:27 Snapshot:   23421 ops,   650.58 ops/sec, Avg Latency:   14.28ms, Success:   23421, Failed:       0
2025/07/28 22:36:28 Snapshot:   23989 ops,   648.34 ops/sec, Avg Latency:   14.33ms, Success:   23989, Failed:       0
2025/07/28 22:36:29 Snapshot:   24493 ops,   644.55 ops/sec, Avg Latency:   14.42ms, Success:   24493, Failed:       0
2025/07/28 22:36:30 Snapshot:   24943 ops,   639.56 ops/sec, Avg Latency:   14.54ms, Success:   24943, Failed:       0
2025/07/28 22:36:31 Snapshot:   25525 ops,   638.12 ops/sec, Avg Latency:   14.58ms, Success:   25525, Failed:       0
2025/07/28 22:36:32 Snapshot:   26134 ops,   637.41 ops/sec, Avg Latency:   14.59ms, Success:   26134, Failed:       0
2025/07/28 22:36:33 Snapshot:   26742 ops,   636.71 ops/sec, Avg Latency:   14.61ms, Success:   26742, Failed:       0
2025/07/28 22:36:34 Snapshot:   27348 ops,   635.99 ops/sec, Avg Latency:   14.63ms, Success:   27348, Failed:       0
2025/07/28 22:36:35 Snapshot:   27970 ops,   635.68 ops/sec, Avg Latency:   14.64ms, Success:   27970, Failed:       0
2025/07/28 22:36:36 Snapshot:   28494 ops,   633.20 ops/sec, Avg Latency:   14.70ms, Success:   28494, Failed:       0
2025/07/28 22:36:37 Snapshot:   28981 ops,   630.02 ops/sec, Avg Latency:   14.78ms, Success:   28981, Failed:       0
2025/07/28 22:36:38 Snapshot:   29581 ops,   629.38 ops/sec, Avg Latency:   14.79ms, Success:   29581, Failed:       0
2025/07/28 22:36:39 Snapshot:   30198 ops,   629.12 ops/sec, Avg Latency:   14.80ms, Success:   30198, Failed:       0
2025/07/28 22:36:40 Snapshot:   30835 ops,   629.28 ops/sec, Avg Latency:   14.80ms, Success:   30835, Failed:       0
2025/07/28 22:36:41 Snapshot:   31470 ops,   629.40 ops/sec, Avg Latency:   14.79ms, Success:   31470, Failed:       0
2025/07/28 22:36:42 Snapshot:   32065 ops,   628.72 ops/sec, Avg Latency:   14.81ms, Success:   32065, Failed:       0
2025/07/28 22:36:43 Snapshot:   32683 ops,   628.51 ops/sec, Avg Latency:   14.82ms, Success:   32683, Failed:       0
2025/07/28 22:36:44 Snapshot:   33308 ops,   628.45 ops/sec, Avg Latency:   14.82ms, Success:   33308, Failed:       0
2025/07/28 22:36:45 Snapshot:   33939 ops,   628.50 ops/sec, Avg Latency:   14.82ms, Success:   33939, Failed:       0
2025/07/28 22:36:46 Snapshot:   34559 ops,   628.34 ops/sec, Avg Latency:   14.82ms, Success:   34559, Failed:       0
2025/07/28 22:36:47 Snapshot:   35177 ops,   628.16 ops/sec, Avg Latency:   14.83ms, Success:   35177, Failed:       0
2025/07/28 22:36:48 Snapshot:   35771 ops,   627.56 ops/sec, Avg Latency:   14.84ms, Success:   35771, Failed:       0
2025/07/28 22:36:49 Snapshot:   36351 ops,   626.74 ops/sec, Avg Latency:   14.86ms, Success:   36351, Failed:       0
2025/07/28 22:36:50 Snapshot:   36980 ops,   626.78 ops/sec, Avg Latency:   14.86ms, Success:   36980, Failed:       0
2025/07/28 22:36:51 Snapshot:   37607 ops,   626.78 ops/sec, Avg Latency:   14.86ms, Success:   37607, Failed:       0
2025/07/28 22:36:52 Snapshot:   38220 ops,   626.55 ops/sec, Avg Latency:   14.87ms, Success:   38220, Failed:       0
2025/07/28 22:36:53 Snapshot:   38828 ops,   626.25 ops/sec, Avg Latency:   14.87ms, Success:   38828, Failed:       0
2025/07/28 22:36:54 Snapshot:   39399 ops,   625.38 ops/sec, Avg Latency:   14.90ms, Success:   39399, Failed:       0
2025/07/28 22:36:55 Snapshot:   40030 ops,   625.46 ops/sec, Avg Latency:   14.89ms, Success:   40030, Failed:       0
2025/07/28 22:36:56 Snapshot:   40637 ops,   625.18 ops/sec, Avg Latency:   14.90ms, Success:   40637, Failed:       0
2025/07/28 22:36:57 Snapshot:   41257 ops,   625.10 ops/sec, Avg Latency:   14.90ms, Success:   41257, Failed:       0
2025/07/28 22:36:58 Snapshot:   41864 ops,   624.83 ops/sec, Avg Latency:   14.91ms, Success:   41864, Failed:       0
2025/07/28 22:36:59 Snapshot:   42387 ops,   623.33 ops/sec, Avg Latency:   14.95ms, Success:   42387, Failed:       0
2025/07/28 22:37:00 Snapshot:   42998 ops,   623.16 ops/sec, Avg Latency:   14.95ms, Success:   42998, Failed:       0
2025/07/28 22:37:01 Snapshot:   43627 ops,   623.24 ops/sec, Avg Latency:   14.95ms, Success:   43627, Failed:       0
2025/07/28 22:37:02 Snapshot:   44244 ops,   623.15 ops/sec, Avg Latency:   14.95ms, Success:   44244, Failed:       0
2025/07/28 22:37:03 Snapshot:   44845 ops,   622.84 ops/sec, Avg Latency:   14.96ms, Success:   44845, Failed:       0
2025/07/28 22:37:04 Snapshot:   45470 ops,   622.87 ops/sec, Avg Latency:   14.96ms, Success:   45470, Failed:       0
2025/07/28 22:37:05 Snapshot:   46084 ops,   622.75 ops/sec, Avg Latency:   14.96ms, Success:   46084, Failed:       0
2025/07/28 22:37:06 Snapshot:   46655 ops,   622.06 ops/sec, Avg Latency:   14.98ms, Success:   46655, Failed:       0
2025/07/28 22:37:07 Snapshot:   47212 ops,   621.20 ops/sec, Avg Latency:   15.00ms, Success:   47212, Failed:       0
2025/07/28 22:37:08 Snapshot:   47825 ops,   621.10 ops/sec, Avg Latency:   15.01ms, Success:   47825, Failed:       0
2025/07/28 22:37:09 Snapshot:   48444 ops,   621.07 ops/sec, Avg Latency:   15.01ms, Success:   48444, Failed:       0
2025/07/28 22:37:10 Snapshot:   49071 ops,   621.15 ops/sec, Avg Latency:   15.01ms, Success:   49071, Failed:       0
2025/07/28 22:37:11 Snapshot:   49686 ops,   621.07 ops/sec, Avg Latency:   15.01ms, Success:   49686, Failed:       0
2025/07/28 22:37:12 Snapshot:   50270 ops,   620.61 ops/sec, Avg Latency:   15.02ms, Success:   50270, Failed:       0
2025/07/28 22:37:13 Snapshot:   50881 ops,   620.50 ops/sec, Avg Latency:   15.02ms, Success:   50881, Failed:       0
2025/07/28 22:37:14 Snapshot:   51498 ops,   620.45 ops/sec, Avg Latency:   15.02ms, Success:   51498, Failed:       0
2025/07/28 22:37:15 Snapshot:   52107 ops,   620.32 ops/sec, Avg Latency:   15.03ms, Success:   52107, Failed:       0
2025/07/28 22:37:16 Snapshot:   52728 ops,   620.33 ops/sec, Avg Latency:   15.03ms, Success:   52728, Failed:       0
2025/07/28 22:37:17 Snapshot:   53359 ops,   620.45 ops/sec, Avg Latency:   15.02ms, Success:   53359, Failed:       0
2025/07/28 22:37:18 Snapshot:   53978 ops,   620.43 ops/sec, Avg Latency:   15.02ms, Success:   53978, Failed:       0
2025/07/28 22:37:19 Snapshot:   54590 ops,   620.34 ops/sec, Avg Latency:   15.03ms, Success:   54590, Failed:       0
2025/07/28 22:37:20 Snapshot:   55213 ops,   620.37 ops/sec, Avg Latency:   15.03ms, Success:   55213, Failed:       0
2025/07/28 22:37:21 Snapshot:   55814 ops,   620.15 ops/sec, Avg Latency:   15.03ms, Success:   55814, Failed:       0
2025/07/28 22:37:22 Snapshot:   56435 ops,   620.16 ops/sec, Avg Latency:   15.03ms, Success:   56435, Failed:       0
2025/07/28 22:37:23 Snapshot:   57047 ops,   620.07 ops/sec, Avg Latency:   15.03ms, Success:   57047, Failed:       0
2025/07/28 22:37:24 Snapshot:   57633 ops,   619.71 ops/sec, Avg Latency:   15.04ms, Success:   57633, Failed:       0
2025/07/28 22:37:25 Snapshot:   58253 ops,   619.71 ops/sec, Avg Latency:   15.04ms, Success:   58253, Failed:       0
2025/07/28 22:37:26 Snapshot:   58869 ops,   619.67 ops/sec, Avg Latency:   15.05ms, Success:   58869, Failed:       0
2025/07/28 22:37:27 Snapshot:   59476 ops,   619.54 ops/sec, Avg Latency:   15.05ms, Success:   59476, Failed:       0
2025/07/28 22:37:28 Snapshot:   60097 ops,   619.55 ops/sec, Avg Latency:   15.05ms, Success:   60097, Failed:       0
2025/07/28 22:37:29 Snapshot:   60730 ops,   619.69 ops/sec, Avg Latency:   15.04ms, Success:   60730, Failed:       0
2025/07/28 22:37:30 Snapshot:   61347 ops,   619.66 ops/sec, Avg Latency:   15.05ms, Success:   61347, Failed:       0
2025/07/28 22:37:31 Snapshot:   61977 ops,   619.77 ops/sec, Avg Latency:   15.04ms, Success:   61977, Failed:       0
2025/07/28 22:37:32 Snapshot:   62595 ops,   619.75 ops/sec, Avg Latency:   15.04ms, Success:   62595, Failed:       0
2025/07/28 22:37:33 Snapshot:   63213 ops,   619.73 ops/sec, Avg Latency:   15.04ms, Success:   63213, Failed:       0
2025/07/28 22:37:34 Snapshot:   63819 ops,   619.60 ops/sec, Avg Latency:   15.05ms, Success:   63819, Failed:       0
2025/07/28 22:37:35 Snapshot:   64439 ops,   619.59 ops/sec, Avg Latency:   15.05ms, Success:   64439, Failed:       0
2025/07/28 22:37:36 Snapshot:   65022 ops,   619.25 ops/sec, Avg Latency:   15.06ms, Success:   65022, Failed:       0
2025/07/28 22:37:37 Snapshot:   65545 ops,   618.35 ops/sec, Avg Latency:   15.08ms, Success:   65545, Failed:       0
2025/07/28 22:37:38 Snapshot:   66154 ops,   618.26 ops/sec, Avg Latency:   15.08ms, Success:   66154, Failed:       0
2025/07/28 22:37:39 Snapshot:   66758 ops,   618.13 ops/sec, Avg Latency:   15.09ms, Success:   66758, Failed:       0
2025/07/28 22:37:40 Snapshot:   67375 ops,   618.12 ops/sec, Avg Latency:   15.09ms, Success:   67375, Failed:       0
2025/07/28 22:37:41 Snapshot:   67971 ops,   617.92 ops/sec, Avg Latency:   15.09ms, Success:   67971, Failed:       0
2025/07/28 22:37:42 Snapshot:   68519 ops,   617.29 ops/sec, Avg Latency:   15.11ms, Success:   68519, Failed:       0
2025/07/28 22:37:43 Snapshot:   69189 ops,   617.76 ops/sec, Avg Latency:   15.09ms, Success:   69189, Failed:       0
2025/07/28 22:37:44 Snapshot:   69892 ops,   618.51 ops/sec, Avg Latency:   15.08ms, Success:   69892, Failed:       0
2025/07/28 22:37:45 Snapshot:   70600 ops,   619.30 ops/sec, Avg Latency:   15.05ms, Success:   70600, Failed:       0
2025/07/28 22:37:46 Snapshot:   71334 ops,   620.29 ops/sec, Avg Latency:   15.03ms, Success:   71334, Failed:       0
2025/07/28 22:37:47 Snapshot:   71918 ops,   619.98 ops/sec, Avg Latency:   15.04ms, Success:   71918, Failed:       0
2025/07/28 22:37:48 Snapshot:   72607 ops,   620.57 ops/sec, Avg Latency:   15.02ms, Success:   72607, Failed:       0
2025/07/28 22:37:49 Snapshot:   73329 ops,   621.43 ops/sec, Avg Latency:   15.00ms, Success:   73329, Failed:       0
2025/07/28 22:37:50 Snapshot:   73997 ops,   621.82 ops/sec, Avg Latency:   14.99ms, Success:   73997, Failed:       0

=== Benchmark Results ===
Scenario: single
Concurrency: 10
Duration: 1m0s
With Lock: false
Backend Type: custom
Race Check: false

Total Operations: 74712
Successful Takes: 74703
Failed Takes: 9
Success Rate: 99.99%
Average Ops/Second: 622.59

Latency Statistics:
  Mean: 14.969819ms
  P50:  14.784979ms
  P95:  17.894676ms
  P99:  26.313492ms
  Max:  137.615833ms
  Min:  457.666µs
```